### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]


### PR DESCRIPTION
Potential fix for [https://github.com/Alcheri/IMDb/security/code-scanning/2](https://github.com/Alcheri/IMDb/security/code-scanning/2)

In general, fix this by explicitly configuring the `permissions` for the workflow or for each job, granting only the minimal scopes required. For a test job that just checks out code and runs tests, `contents: read` is typically sufficient.

For this specific workflow in `.github/workflows/test.yml`, the best minimal change is to add a `permissions` block under the `test` job. This limits the `GITHUB_TOKEN` used in that job to read-only access to repository contents, which is enough for `actions/checkout@v4` and the rest of the steps while preserving all existing behavior. No additional imports or external libraries are needed; this is purely a YAML configuration change.

Concretely, edit `.github/workflows/test.yml` and insert:

```yaml
    permissions:
      contents: read
```

directly under `runs-on: ubuntu-latest` (line 9), keeping indentation consistent with other job-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
